### PR TITLE
Allow factions, systems, and stations to have pasted spaces

### DIFF
--- a/frontend/src/components/main/stations/StationList.vue
+++ b/frontend/src/components/main/stations/StationList.vue
@@ -88,7 +88,7 @@ export default {
           this.loading = true
           return this.$store.dispatch('fetchStations', {
             page: this.page,
-            beginsWith: value.newValue
+            beginsWith: value.newValue.trim()
           })
         })
       )
@@ -114,7 +114,7 @@ export default {
       this.loading = true
       let stationsPaginated = await this.$store.dispatch('fetchStations', {
         page: this.page,
-        beginsWith: this.stationName
+        beginsWith: this.stationName.trim()
       })
       this.setStations(stationsPaginated.docs)
       this.totalStations = stationsPaginated.total

--- a/frontend/src/mixins/factionMethods.js
+++ b/frontend/src/mixins/factionMethods.js
@@ -3,7 +3,7 @@ export default {
     fetchFactionsCall(page, factionName) {
       return this.$store.dispatch('fetchFactions', {
         page: page,
-        beginsWith: factionName
+        beginsWith: factionName.trim()
       })
     }
   }

--- a/frontend/src/mixins/systemMethods.js
+++ b/frontend/src/mixins/systemMethods.js
@@ -3,7 +3,7 @@ export default {
     fetchSystemsCall(page, systemName) {
       return this.$store.dispatch('fetchSystems', {
         page: page,
-        beginsWith: systemName
+        beginsWith: systemName.trim()
       })
     }
   }


### PR DESCRIPTION
Many tools copy additional whitespace. This small enhancement ignores these pasted values. I decided to do this in the frontend only, because the backend API is assumed to be called by folks who can trim if they want to do so.