### PR TITLE
Base v-chip color off whether info is current this tick, instead of 24 hours

### DIFF
--- a/frontend/src/components/main/factions/FactionTable.vue
+++ b/frontend/src/components/main/factions/FactionTable.vue
@@ -2,8 +2,8 @@
   <v-data-table
     class="elevation-1"
     :headers="headers"
-    :items="systemDetails"
-    :items-per-page="systemDetails.length"
+    :items="tableDetails"
+    :items-per-page="tableDetails.length"
     :search="factionFilter"
     hide-default-footer
     :loading="loading"
@@ -50,7 +50,7 @@
     </template>
     <template v-slot:item.updated_at="{ item }">
       {{ formatDate(item.updated_at) }}
-      <v-chip small :color="item.age_flag" dark>
+      <v-chip small :color="item.isCurrentTick ? 'success' : 'error'" dark>
         {{ item.from_now }}
       </v-chip>
     </template>
@@ -58,6 +58,8 @@
 </template>
 
 <script>
+import moment from 'moment'
+import { mapState } from 'vuex'
 import componentMethods from '@/mixins/componentMethods'
 
 export default {
@@ -115,6 +117,19 @@ export default {
           filterable: false
         }
       ]
+    }
+  },
+  computed: {
+    ...mapState({
+      currentTick: (state) => state.ticks.currentTick
+    }),
+    tableDetails() {
+      return this.systemDetails.map((d) => {
+        return {
+          ...d,
+          isCurrentTick: moment(this.currentTick.time).isBefore(moment(d.system_updated_at))
+        }
+      })
     }
   },
   mixins: [componentMethods],

--- a/frontend/src/components/main/systems/SystemTable.vue
+++ b/frontend/src/components/main/systems/SystemTable.vue
@@ -2,8 +2,8 @@
   <v-data-table
     class="elevation-1"
     :headers="headers"
-    :items="factionDetails"
-    :items-per-page="factionDetails.length"
+    :items="tableDetails"
+    :items-per-page="tableDetails.length"
     :search="systemFilter"
     hide-default-footer
     :loading="loading"
@@ -49,7 +49,7 @@
     <template v-slot:item.influence="{ item }"> {{ item.influence.toFixed(2) }}% </template>
     <template v-slot:item.updated_at="{ item }">
       {{ formatDate(item.updated_at) }}
-      <v-chip small :color="item.age_flag" dark>
+      <v-chip small :color="item.isCurrentTick ? 'success' : 'error'" dark>
         {{ item.from_now }}
       </v-chip>
     </template>
@@ -57,6 +57,8 @@
 </template>
 
 <script>
+import moment from 'moment'
+import { mapState } from 'vuex'
 import componentMethods from '@/mixins/componentMethods'
 
 export default {
@@ -109,6 +111,19 @@ export default {
           filterable: false
         }
       ]
+    }
+  },
+  computed: {
+    ...mapState({
+      currentTick: (state) => state.ticks.currentTick
+    }),
+    tableDetails() {
+      return this.systemDetails.map((d) => {
+        return {
+          ...d,
+          isCurrentTick: moment(this.currentTick.time).isBefore(moment(d.system_updated_at))
+        }
+      })
     }
   },
   mixins: [componentMethods],

--- a/frontend/src/store/helpers.js
+++ b/frontend/src/store/helpers.js
@@ -75,8 +75,8 @@ const systemDetailsTable = (system, faction) => {
     name: system.system_name,
     population: system.system_details.population,
     system_id: system.system_id,
-    from_now: moment(system.updated_at).fromNow(true),
-    age_flag: getChipColour(-(moment().diff(moment(system.updated_at), 'days', true) - 1))
+    system_updated_at: system.updated_at,
+    from_now: moment(system.updated_at).fromNow(true)
   }
 }
 
@@ -134,10 +134,8 @@ const factionDetailsTable = (faction, system) => {
     influence: faction.faction_details.faction_presence.influence * 100,
     name: faction.name,
     faction_id: faction.faction_id,
-    from_now: moment(faction.faction_details.faction_presence.updated_at).fromNow(true),
-    age_flag: getChipColour(
-      -(moment().diff(moment(faction.faction_details.faction_presence.updated_at), 'days', true) - 1)
-    )
+    system_updated_at: faction.faction_details.faction_presence.updated_at,
+    from_now: moment(faction.faction_details.faction_presence.updated_at).fromNow(true)
   }
 }
 


### PR DESCRIPTION
This changes the `v-chip` color in the `FactionTable` and `SystemTable` to choose the color based whether that information is current as of the most recent tick, instead of on whether 24 hours has past.

Note the first two entries in this table as an example:
![image](https://user-images.githubusercontent.com/10985/132898543-7043b28c-3ab7-4394-97b5-935b70dc9545.png)

## Why?

90% of the time I'm using elitebgs, I'm doing BGS runs and just want to know which of our faction's systems I need to hit vs which ones I can skip. This makes it easy to see at a glance whether the information is current as of the latest tick. 